### PR TITLE
Hot-Fix: Fix parser/eval combo not reading integers for Credits

### DIFF
--- a/Eval.sml
+++ b/Eval.sml
@@ -48,24 +48,22 @@ structure Eval = struct
         (case readNames tks env of NONE => NONE
         | SOME (nameX, numsX, tks2) =>
           (case tks2 of
-          tok :: Assign :: tks3 =>
-            if (tok = Gold orelse tok = Silver orelse tok = Iron) then
-              case readNames tks3 env of NONE => NONE
-              | SOME (nameY, numsY, tks4) =>
-                (let
-                  (** ratio for value in credits of 1 unit *)
-                  val value = (sum numsY) div (sum numsX)
-                  val newVals =
-                    (* match non-exhaustive, if check before ensures that no other
-                      value can occur *)
-                    case tok of
+          tok :: Assign :: Int i :: tks3 =>
+            if tok = Gold orelse tok = Silver orelse tok = Iron then
+              (let
+              (** ratio for value in credits of 1 unit *)
+                val value = i div (sum numsX)
+                val newVals =
+                (* match non-exhaustive, if check before ensures that no other
+                   value can occur *)
+                  case tok of
                     Gold => {gold = SOME value, silver = silverOpt, iron = ironOpt}
                     | Silver => {gold = goldOpt, silver = SOME value , iron = ironOpt}
                     | Iron => {gold = goldOpt, silver = silverOpt, iron = SOME value}
-                in
-                  SOME (newVals, env, NONE)
-                end
-                handle IllegalFormat => NONE) (* TODO print exception *)
+              in
+                SOME (newVals, env, NONE)
+              end
+              handle IllegalFormat => NONE) (* TODO print exception *)
             else NONE
           | _ => NONE))
       | Sum :: tks2 =>

--- a/Parser.sml
+++ b/Parser.sml
@@ -16,6 +16,7 @@ structure Parser = struct
     | Iron
     | Credits
     | Name of string
+    | Int of int
     | End
     | Sum
     | Convert
@@ -54,7 +55,7 @@ structure Parser = struct
       | "Credits" => Credits
       | "?" => End
       | "is" => Assign
-      | _ => Name tok) :: tokenize ss2;
+      | _ => case Int.fromString tok of NONE => Name tok |SOME i => Int i) :: tokenize ss2;
 
   fun valOf (n : number): int =
     case n of

--- a/tests/EvalIntegrationTest.sml
+++ b/tests/EvalIntegrationTest.sml
@@ -1,0 +1,13 @@
+structure EvalIntegrationTest = struct
+
+  open Eval;
+
+  fun test() = let
+    val _ = check (run ["glob", "is", "I"] = "")
+                  "Assignments should be silent"
+    val _ = check (run ["how", "much", "is", "glob"] = "glob is I")
+    val _ = check (run ["glob", "Silver", "is", "1", "Credits"] = "")
+                  "COnversions should be silent"
+    in () end;
+
+end

--- a/tests/EvalUnitTests.sml
+++ b/tests/EvalUnitTests.sml
@@ -19,7 +19,7 @@ structure EvalUnitTests = struct
                     eval [Sum, Name "x", End] emptyValuation (("x", V)::cnstXIenv) =
                       SOME (emptyValuation, ("x", V)::cnstXIenv, SOME (SumRes ("x", 5)) ))
               "Assignment does not properly overwrite old values"
-    val _ = check (eval [Name "x", Silver, Assign, Name "x", Credits]
+    val _ = check (eval [Name "x", Silver, Assign, Int 1, Credits]
                         emptyValuation cnstXIenv =
                     SOME (silverOneVal, cnstXIenv, NONE))
               "Assignment of credit values not properly implemented"


### PR DESCRIPTION
While writing integration tests for the evaluator, I noticed the following issue.
Currently, the parser reades only lines of the form 

    glob proj Silver is glob Credits

where it should read

    glob proj Silver is 5 Credits

instead.

This PR addresses this issue.