### PR TITLE
Make the REPL terminate when sending quit, add full end-to-end test

### DIFF
--- a/Eval.sml
+++ b/Eval.sml
@@ -100,23 +100,27 @@ structure Eval = struct
       end
   end
 
+  datatype evalRes = Cont of string | Fail of string | Term;
+
   local
     val currVals = ref { gold = NONE, silver = NONE, iron = NONE};
     val currEnv = ref [];
   in
-    fun run (strs: string list) : string = let
+    fun run (strs: string list) : evalRes = let
       val toks = Parser.tokenize strs
       in
-        case eval toks (!currVals) (!currEnv) of
-        NONE => "I have no idea what you are talking about"
-        | SOME (newVals, newEnv, res) =>
-          (currVals := newVals;
-            currEnv := newEnv;
-            case res of
-            NONE => ""
-            | SOME (SumRes (ss, i)) => (ss ^ " is " ^ (Int.toString i))
-            | SOME (Conv (ss, i)) => (ss ^ " is " ^ (Real.toString i) ^ " Credits"))
-        end
+        if toks = [Quit] then Term
+        else
+          case eval toks (!currVals) (!currEnv) of
+          NONE => Fail "I have no idea what you are talking about"
+          | SOME (newVals, newEnv, res) =>
+            (currVals := newVals;
+              currEnv := newEnv;
+              case res of
+              NONE => Cont ""
+              | SOME (SumRes (ss, i)) => Cont (ss ^ " is " ^ (Int.toString i))
+              | SOME (Conv (ss, i)) => Cont (ss ^ " is " ^ (Real.toString i) ^ " Credits"))
+          end
   end
 
 end

--- a/Main.sml
+++ b/Main.sml
@@ -12,12 +12,20 @@ PolyML.make "Reader";
     fun evalStep() =
       let
         val line = Reader.read()
-        val result = run line
       in
-        print result
+        run line
       end;
+
     fun loop() =
-      (prompt(); evalStep(); print "\n"; loop())
+      let
+        val _ = prompt();
+        val res = evalStep();
+      in
+        case res of
+        Term => print "Thank you.\n"
+        | Cont s => (print (s^"\n"); loop())
+        | Fail s => (print (s^"\n"); loop())
+      end
   in
     fun main () =
       (greet(); loop());

--- a/Parser.sml
+++ b/Parser.sml
@@ -20,6 +20,7 @@ structure Parser = struct
     | End
     | Sum
     | Convert
+    | Quit
 
   fun consume (elem:''a) (ss:''a list) =
     case ss of [] => raise NotFound
@@ -40,6 +41,7 @@ structure Parser = struct
         else
           let val ss3 = consume "many" ss2
           in Convert :: tokenize ss3 end
+      else if tok = "quit" then [Quit]
       else
       (case tok of
        "I" => Num I

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -12,3 +12,14 @@ if [ $? = 1 ];
 then echo "Tests failed"
 else echo "Tests successfull"
 fi
+
+echo "Running example file"
+./scripts/build.sh
+
+./galaxyMerchant < testcases/example1.txt > /tmp/out1.txt
+diff -q /tmp/out1.txt testcases/example1_output.txt
+
+if [ $? = 1 ];
+then echo "Example script failed"
+else echo "Example script succeeded"
+fi

--- a/testcases/example1.txt
+++ b/testcases/example1.txt
@@ -1,0 +1,12 @@
+glob is I
+prok is V
+pish is X
+tegj is L
+glob glob Silver is 34 Credits
+glob prok Gold is 57800 Credits
+pish pish Iron is 3910 Credits
+how much is pish tegj glob glob ?
+how many Credits is glob prok Silver ?
+how many Credits is glob prok Gold ?
+how many Credits is glob prok Iron ?
+quit

--- a/testcases/example1_output.txt
+++ b/testcases/example1_output.txt
@@ -1,0 +1,13 @@
+Welcome to the Galaxy Merchant. Please enter your query
+> 
+> 
+> 
+> 
+> 
+> 
+> 
+> pish tegj glob glob is 42
+> glob prok Silver is 68.0 Credits
+> glob prok Gold is 57800.0 Credits
+> glob prok Iron is 782.0 Credits
+> Thank you.

--- a/tests/EvalIntegrationTests.sml
+++ b/tests/EvalIntegrationTests.sml
@@ -4,42 +4,42 @@ structure EvalIntegrationTests = struct
   open Eval;
 
   fun test() = let
-    val _ = check (run ["glob", "is", "I"] = "")
+    val _ = check (run ["glob", "is", "I"] = Cont "")
                   "Assignments should be silent"
-    val _ = check (run ["how", "much", "is", "glob"] = "glob is I")
-    val _ = check (run ["glob", "Silver", "is", "1", "Credits"] = "")
+    val _ = check (run ["how", "much", "is", "glob"] = Cont "glob is I")
+    val _ = check (run ["glob", "Silver", "is", "1", "Credits"] = Cont "")
                   "Conversions should be silent"
     (** Tests from description below **)
-    val _ = check (run ["glob", "is", "I"] = "")
+    val _ = check (run ["glob", "is", "I"] = Cont "")
                   "First example line broken"
-    val _ = check (run ["prok", "is", "V"] = "")
+    val _ = check (run ["prok", "is", "V"] = Cont "")
                   "Second example line broken"
-    val _ = check (run ["pish", "is", "X"] = "")
+    val _ = check (run ["pish", "is", "X"] = Cont "")
                   "Third example line broken"
-    val _ = check (run ["tegj", "is", "L"] = "")
+    val _ = check (run ["tegj", "is", "L"] = Cont "")
                   "4th example line broken"
-    val _ = check (run ["glob", "glob", "Silver", "is", "34", "Credits"] = "")
+    val _ = check (run ["glob", "glob", "Silver", "is", "34", "Credits"] = Cont "")
                   "5th example line broken"
-    val _ = check (run ["glob", "prok", "Gold", "is", "57800", "Credits"] = "")
+    val _ = check (run ["glob", "prok", "Gold", "is", "57800", "Credits"] = Cont "")
                       "6th example line broken"
-    val _ = check (run ["pish", "pish", "Iron", "is", "3910", "Credits"] = "")
+    val _ = check (run ["pish", "pish", "Iron", "is", "3910", "Credits"] = Cont "")
                       "7th example line broken"
     val _ = check (run ["how", "much", "is", "pish", "tegj", "glob", "glob", "?"] =
-                      "pish tegj glob glob is 42")
+                      Cont "pish tegj glob glob is 42")
                       "8th example line broken"
     val _ = check (run ["how", "many", "Credits", "is", "glob", "prok", "Silver", "?"] =
-                      "glob prok Silver is 68.0 Credits")
+                      Cont "glob prok Silver is 68.0 Credits")
                       "9th example line broken"
     val _ = check (run ["how", "many", "Credits", "is", "glob", "prok", "Gold", "?"] =
-                      "glob prok Gold is 57800.0 Credits")
+                      Cont "glob prok Gold is 57800.0 Credits")
                       "10th example line broken"
     val _ = check (run ["how", "many", "Credits", "is", "glob", "prok", "Iron", "?"] =
-                      "glob prok Iron is 782.0 Credits")
+                      Cont "glob prok Iron is 782.0 Credits")
                       "11th example line broken"
     val _ = check (run ["how", "much", "wood", "could", "a", "woodchuck",
                         "chuck", "if", "a", "woodchuck", "could", "chuck",
                         "wood"] =
-                    "I have no idea what you are talking about")
+                    Fail "I have no idea what you are talking about")
                   "Not passing negative example test from description"
     in () end;
 


### PR DESCRIPTION
This PR makes sure that the REPL can be quit properly with the `quit` keyword, and adds a full end-to-end test in `testcases/example1.txt` which tests the full binary produced by the pipeline. The example output is in `testcases/example1_output.txt` and compared against the result by the script `scripts/test.sh` which is run by every GitHub action.